### PR TITLE
Add support for fractions

### DIFF
--- a/Sources/Swift-ISO8601-DurationParser/Swift_ISO8601_DurationParser.swift
+++ b/Sources/Swift-ISO8601-DurationParser/Swift_ISO8601_DurationParser.swift
@@ -39,7 +39,7 @@ public extension DateComponents {
         try? Self.from8601String(durationString)
     }
 
-    // Note: Does not handle decimal values or overflow values
+    // Note: Does not handle fractional values for months
     // Format: PnYnMnDTnHnMnS or PnW
     static func from8601String(_ durationString: String) throws -> DateComponents {
         guard durationString.starts(with: "P") else {
@@ -49,13 +49,9 @@ public extension DateComponents {
         let durationString = String(durationString.dropFirst())
         var dateComponents = DateComponents()
 
-        if durationString.contains("W") {
-            let weekValues = try componentsForString(durationString, designatorSet: CharacterSet(charactersIn: "W"))
-
-            if let weekValue = weekValues["W"], let weekValueDouble = Double(weekValue) {
-                // 7 day week specified in ISO 8601 standard
-                dateComponents.day = Int(weekValueDouble * 7.0)
-            }
+        if let week = componentFor("W", in: durationString) {
+            // 7 day week specified in ISO 8601 standard
+            dateComponents.day = Int(week * 7.0)
             return dateComponents
         }
 
@@ -71,38 +67,60 @@ public extension DateComponents {
         }
 
         // DnMnYn
-        let periodValues = try componentsForString(periodString, designatorSet: CharacterSet(charactersIn: "YMD"))
-        dateComponents.day = Int(periodValues["D"] ?? "")
-        dateComponents.month = Int(periodValues["M"] ?? "")
-        dateComponents.year = Int(periodValues["Y"] ?? "")
+        let year = componentFor("Y", in: periodString)
+        let month = componentFor("M", in: periodString).addingFractionsFrom(year, multiplier: 12)
+        let day = componentFor("D", in: periodString)
+
+        if let monthFraction = month?.truncatingRemainder(dividingBy: 1),
+            monthFraction != 0 {
+            // Representing fractional months isn't supported by DateComponents, so we don't allow it here
+            throw DurationParsingError.unsupportedFractionsForMonth(durationString)
+        }
+
+        dateComponents.year = year?.nonFractionParts
+        dateComponents.month = month?.nonFractionParts
+        dateComponents.day = day?.nonFractionParts
 
         // SnMnHn
-        let timeValues = try componentsForString(timeString, designatorSet: CharacterSet(charactersIn: "HMS"))
-        dateComponents.second = Int(timeValues["S"] ?? "")
-        dateComponents.minute = Int(timeValues["M"] ?? "")
-        dateComponents.hour = Int(timeValues["H"] ?? "")
+        let hour = componentFor("H", in: timeString).addingFractionsFrom(day, multiplier: 24)
+        let minute = componentFor("M", in: timeString).addingFractionsFrom(hour, multiplier: 60)
+        let second = componentFor("S", in: timeString).addingFractionsFrom(minute, multiplier: 60)
+        dateComponents.hour = hour?.nonFractionParts
+        dateComponents.minute = minute?.nonFractionParts
+        dateComponents.second = second?.nonFractionParts
 
         return dateComponents
     }
 
-    private static func componentsForString(_ string: String, designatorSet: CharacterSet) throws -> [String: String] {
-        if string.isEmpty {
-            return [:]
-        }
-
-        let componentValues = string.components(separatedBy: designatorSet).filter { !$0.isEmpty }
-        let designatorValues = string.components(separatedBy: .decimalDigits).filter { !$0.isEmpty }
-
-        guard componentValues.count == designatorValues.count else {
-            throw DurationParsingError.invalidFormat(string)
-        }
-
-        return Dictionary(uniqueKeysWithValues: zip(designatorValues, componentValues))
+    private static func componentFor(_ designator: String, in string: String) -> Double? {
+        // First split by the designator we're interested in, and then split by all separators. This should give us whatever's before our designator, but after the previous one.
+        let beforeDesignator = string.components(separatedBy: designator).first?.components(separatedBy: .separators).last
+        return beforeDesignator.flatMap { Double($0) }
     }
 
     enum DurationParsingError: Error {
         case invalidFormat(String)
+        case unsupportedFractionsForMonth(String)
     }
+}
+
+private extension Optional where Wrapped == Double {
+    func addingFractionsFrom(_ other: Double?, multiplier: Double) -> Self {
+        guard let other = other else { return self }
+        let toAdd = other.truncatingRemainder(dividingBy: 1) * multiplier
+        guard let self = self else { return toAdd }
+        return self + toAdd
+    }
+}
+
+private extension Double {
+    var nonFractionParts: Int {
+        Int(floor(self))
+    }
+}
+
+private extension CharacterSet {
+    static let separators = CharacterSet(charactersIn: "PWTYMDHMS")
 }
 
 extension DateComponents.DurationParsingError: LocalizedError {
@@ -110,6 +128,8 @@ extension DateComponents.DurationParsingError: LocalizedError {
         switch self {
         case .invalidFormat(let durationString):
             return "\(durationString) has an invalid format, The durationString must have a format of PnYnMnDTnHnMnS or PnW"
+        case .unsupportedFractionsForMonth(let durationString):
+            return "\(durationString) has an invalid format, fractions aren't supported for the month-position"
         }
     }
 }

--- a/Tests/Swift-ISO8601-DurationParserTests/Swift_ISO8601_DurationParserTests.swift
+++ b/Tests/Swift-ISO8601-DurationParserTests/Swift_ISO8601_DurationParserTests.swift
@@ -3,54 +3,52 @@ import XCTest
 
 final class Swift_ISO8601_DurationParserTests: XCTestCase {
     func testIndividualYearsParsedCorrectly() {
-        let dateComponents = DateComponents.durationFrom8601String("P1Y")
-        XCTAssertEqual(dateComponents?.year, 1)
+        let dateComponents = try! DateComponents.from8601String("P1Y")
+        XCTAssertEqual(dateComponents.year, 1)
     }
 
     func testIndividualMonthsParsedCorrectly() {
-        let dateComponents = DateComponents.durationFrom8601String("P2M")
-        XCTAssertEqual(dateComponents?.month, 2)
+        let dateComponents = try! DateComponents.from8601String("P2M")
+        XCTAssertEqual(dateComponents.month, 2)
     }
 
     func testIndividualDaysParsedCorrectly() {
-        let dateComponents = DateComponents.durationFrom8601String("P3D")
-        XCTAssertEqual(dateComponents?.day, 3)
+        let dateComponents = try! DateComponents.from8601String("P3D")
+        XCTAssertEqual(dateComponents.day, 3)
     }
 
     func testIndividualHoursParsedCorrectly() {
-        let dateComponents = DateComponents.durationFrom8601String("PT11H")
-        XCTAssertEqual(dateComponents?.hour, 11)
+        let dateComponents = try! DateComponents.from8601String("PT11H")
+        XCTAssertEqual(dateComponents.hour, 11)
     }
 
     func testIndividualMinutesParsedCorrectly() {
-        let dateComponents = DateComponents.durationFrom8601String("PT42M")
-        XCTAssertEqual(dateComponents?.minute, 42)
+        let dateComponents = try! DateComponents.from8601String("PT42M")
+        XCTAssertEqual(dateComponents.minute, 42)
     }
 
     func testIndividualSecondsParsedCorrectly() {
-        let dateComponents = DateComponents.durationFrom8601String("PT32S")
-        XCTAssertEqual(dateComponents?.second, 32)
+        let dateComponents = try! DateComponents.from8601String("PT32S")
+        XCTAssertEqual(dateComponents.second, 32)
     }
 
     func testWeeksParsedCorrectly() {
-        let dateComponents = DateComponents.durationFrom8601String("P8W")
-        XCTAssertEqual(dateComponents?.day, 56)
+        let dateComponents = try! DateComponents.from8601String("P8W")
+        XCTAssertEqual(dateComponents.day, 56)
     }
 
     func testFullStringParsedCorrectly() {
-        let dateComponents = DateComponents.durationFrom8601String("P3Y6M4DT12H30M5S")
-        XCTAssertEqual(dateComponents?.year, 3)
-        XCTAssertEqual(dateComponents?.month, 6)
-        XCTAssertEqual(dateComponents?.day, 4)
-        XCTAssertEqual(dateComponents?.hour, 12)
-        XCTAssertEqual(dateComponents?.minute, 30)
-        XCTAssertEqual(dateComponents?.second, 5)
+        let dateComponents = try! DateComponents.from8601String("P3Y6M4DT12H30M5S")
+        XCTAssertEqual(dateComponents.year, 3)
+        XCTAssertEqual(dateComponents.month, 6)
+        XCTAssertEqual(dateComponents.day, 4)
+        XCTAssertEqual(dateComponents.hour, 12)
+        XCTAssertEqual(dateComponents.minute, 30)
+        XCTAssertEqual(dateComponents.second, 5)
     }
 
     func testDurationStringNotStartingWithPReturnsNil() {
-        let dateComponents = DateComponents.durationFrom8601String("3Y6M4DT12H30M5S")
-        let dateComponents2 = DateComponents.durationFrom8601String("8W")
-        XCTAssertNil(dateComponents)
-        XCTAssertNil(dateComponents2)
+        XCTAssertThrowsError(try DateComponents.from8601String("3Y6M4DT12H30M5S"))
+        XCTAssertThrowsError(try DateComponents.from8601String("8W"))
     }
 }

--- a/Tests/Swift-ISO8601-DurationParserTests/Swift_ISO8601_DurationParserTests.swift
+++ b/Tests/Swift-ISO8601-DurationParserTests/Swift_ISO8601_DurationParserTests.swift
@@ -51,4 +51,12 @@ final class Swift_ISO8601_DurationParserTests: XCTestCase {
         XCTAssertThrowsError(try DateComponents.from8601String("3Y6M4DT12H30M5S"))
         XCTAssertThrowsError(try DateComponents.from8601String("8W"))
     }
+
+    func testParsingFractions() {
+        let string = "PT0.5H45S"
+        let dateComponents = try! DateComponents.from8601String(string)
+        XCTAssertEqual(dateComponents.hour, 0)
+        XCTAssertEqual(dateComponents.minute, 30)
+        XCTAssertEqual(dateComponents.second, 45)
+    }
 }

--- a/Tests/Swift-ISO8601-DurationParserTests/XCTestManifests.swift
+++ b/Tests/Swift-ISO8601-DurationParserTests/XCTestManifests.swift
@@ -14,6 +14,7 @@ extension Swift_ISO8601_DurationParserTests {
         ("testIndividualMonthsParsedCorrectly", testIndividualMonthsParsedCorrectly),
         ("testIndividualSecondsParsedCorrectly", testIndividualSecondsParsedCorrectly),
         ("testIndividualYearsParsedCorrectly", testIndividualYearsParsedCorrectly),
+        ("testParsingFractions", testParsingFractions),
         ("testWeeksParsedCorrectly", testWeeksParsedCorrectly),
     ]
 }


### PR DESCRIPTION
Add support for fractional values, for everything but months.

It's not trivial to add this support for months, since `DateComponents` don't have a concept of fractions (it's all `Int`:s), but for all other positions it's just arithmetic.

Fixes #3
